### PR TITLE
Fix deprecated import of DOCUMENT

### DIFF
--- a/src/I18NextTitle.ts
+++ b/src/I18NextTitle.ts
@@ -1,5 +1,6 @@
-import { Injectable, Inject } from '@angular/core';
-import { Title, DOCUMENT } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { I18NextPipe } from './I18NextPipe';
 
 @Injectable()


### PR DESCRIPTION
This PR fixes issue https://github.com/Romanchuk/angular-i18next/issues/30. According to the (Angular documentation](https://angular.io/api/platform-browser) for `platform-browser`, `DOCUMENT` should be imported from `@angular/common` from now on.