### PR TITLE
fix: Fixes i18next format call with options undefined

### DIFF
--- a/libs/angular-i18next/src/lib/I18NextService.ts
+++ b/libs/angular-i18next/src/lib/I18NextService.ts
@@ -82,7 +82,7 @@ export class I18NextService implements ITranslationService {
   }
 
   public format(value: any, format?: string, lng?: string): string {
-    return i18next.format.call(i18next, value, format, lng);
+    return i18next.format.call(i18next, value, format, lng, {});
   }
 
   public exists(key: string | string[], options: any) {


### PR DESCRIPTION
When trying to use formatters it fails with `Cannot read properties of undefined (reading 'locale')` which is because no `options` is being passed to `i18next.format()` function.

At this line https://github.com/i18next/i18next/blob/9304a251e54d58cda88fb484299bef67f2025c2e/src/Formatter.js#L95 you can find where options.locale fails if undefined is passed