### PR TITLE
Update I18NextEagerPipe.ts to trigger change detection inside NgZone

### DIFF
--- a/libs/angular-i18next/src/lib/I18NextEagerPipe.ts
+++ b/libs/angular-i18next/src/lib/I18NextEagerPipe.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectorRef,
   Inject,
+  NgZone,
   OnDestroy,
   Pipe,
   PipeTransform,
@@ -34,13 +35,14 @@ export class I18NextEagerPipe
     @Inject(I18NEXT_SERVICE) protected override translateI18Next: ITranslationService,
     @Inject(I18NEXT_NAMESPACE) protected override ns: string | string[],
     @Inject(I18NEXT_SCOPE) protected override scope: string | string[],
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private ngZone: NgZone  
   ) {
     super(translateI18Next, ns, scope);
     translateI18Next.events.languageChanged
       .pipe(takeUntil(this.ngUnsubscribe))
       .subscribe(() => {
-        this.cd.markForCheck();
+        this.ngZone.run(() => this.cd.markForCheck());
       });
   }
   private hasKeyChanged(key: string | string[]): boolean {


### PR DESCRIPTION
For microfrontend architectures (e.g. [Single Spa](https://single-spa.js.org/) ), it will be necessary to detect language changes across all applications that are started on screen (e.g. Side Menu App and Main Content App 2). However, in order to do so in these types of architectures, the change detection needs to be triggered by also notifying the NgZone of the application (refer to here https://github.com/single-spa/single-spa-angular/issues/360). As an example, consider detect ing language change triggered from Side Menu App inside Main Content App